### PR TITLE
Add Command History

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -44,16 +44,16 @@ public class CommandBox extends UiPart<Region> {
             if (previous != null) {
                 commandTextField.setText(previous);
                 commandTextField.positionCaret(previous.length());
+                event.consume();
             }
-            event.consume();
             break;
         case DOWN:
             String next = commandHistory.getNext();
             if (next != null) {
                 commandTextField.setText(next);
                 commandTextField.positionCaret(next.length());
+                event.consume();
             }
-            event.consume();
             break;
         default:
             break;
@@ -66,7 +66,7 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleCommandEntered() {
         String commandText = commandTextField.getText();
-        if (commandText.equals("")) {
+        if (commandText.isBlank()) {
             return;
         }
 

--- a/src/main/java/seedu/address/ui/CommandHistory.java
+++ b/src/main/java/seedu/address/ui/CommandHistory.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +26,7 @@ public class CommandHistory {
      * the oldest command is removed. Resets the navigation index to the end.
      */
     public void add(String command) {
+        requireNonNull(command);
         history.add(command);
         if (history.size() > MAX_HISTORY_SIZE) {
             history.remove(0);

--- a/src/test/java/seedu/address/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/ui/CommandHistoryTest.java
@@ -1,0 +1,107 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryTest {
+
+    private CommandHistory history;
+
+    @BeforeEach
+    public void setUp() {
+        history = new CommandHistory();
+    }
+
+    @Test
+    public void getPrevious_emptyHistory_returnsNull() {
+        assertNull(history.getPrevious());
+    }
+
+    @Test
+    public void getNext_emptyHistory_returnsNull() {
+        assertNull(history.getNext());
+    }
+
+    @Test
+    public void getPrevious_singleCommand_returnsCommand() {
+        history.add(":list");
+        assertEquals(":list", history.getPrevious());
+    }
+
+    @Test
+    public void getPrevious_atOldestCommand_returnsNull() {
+        history.add(":list");
+        history.getPrevious(); // now at index 0
+        assertNull(history.getPrevious());
+    }
+
+    @Test
+    public void getNext_pastNewestCommand_returnsEmptyString() {
+        history.add(":list");
+        history.getPrevious(); // navigate back
+        assertEquals("", history.getNext()); // navigate forward past newest
+    }
+
+    @Test
+    public void getNext_alreadyPastNewest_returnsNull() {
+        history.add(":list");
+        history.getPrevious();
+        history.getNext(); // now at "new command" position
+        assertNull(history.getNext());
+    }
+
+    @Test
+    public void navigation_multipleCommands_correctOrder() {
+        history.add(":list");
+        history.add(":find Alice");
+        history.add(":delete 1");
+
+        assertEquals(":delete 1", history.getPrevious());
+        assertEquals(":find Alice", history.getPrevious());
+        assertEquals(":list", history.getPrevious());
+        assertNull(history.getPrevious());
+
+        assertEquals(":find Alice", history.getNext());
+        assertEquals(":delete 1", history.getNext());
+        assertEquals("", history.getNext());
+        assertNull(history.getNext());
+    }
+
+    @Test
+    public void add_resetsIndexToEnd() {
+        history.add(":list");
+        history.add(":find Alice");
+        history.getPrevious(); // :find Alice
+        history.getPrevious(); // :list
+
+        history.add(":help");
+        // index should be reset; getPrevious returns the newest command
+        assertEquals(":help", history.getPrevious());
+    }
+
+    @Test
+    public void add_exceedsMaxSize_dropsOldest() {
+        for (int i = 0; i < CommandHistory.MAX_HISTORY_SIZE + 5; i++) {
+            history.add(":command" + i);
+        }
+
+        assertEquals(CommandHistory.MAX_HISTORY_SIZE, history.size());
+
+        // Navigate to the oldest — should be command 5 (0–4 were dropped)
+        String oldest = null;
+        String command;
+        while ((command = history.getPrevious()) != null) {
+            oldest = command;
+        }
+        assertEquals(":command5", oldest);
+    }
+
+    @Test
+    public void add_nullCommand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> history.add(null));
+    }
+}


### PR DESCRIPTION
Closes #61 

## Summary
- Add command history navigation to the command box using UP/DOWN arrow keys
- Users can cycle through up to 64 previously entered commands
- Pressing UP recalls older commands, DOWN recalls newer ones, and navigating past the newest command clears the input field