### PR TITLE
Fix Tag related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -95,9 +95,11 @@ To add a contact, simply type `:add` followed by the details of the contact you 
 - The contact’s house address, typed after `a/`.
 - Any tags you wish to identify the contact with, typed after `t/`, and each additional tag after the first one separated by `t/`.
 
-Note: All parameters are required except for tags. A contact can have any number of tags (including 0).
+Note: All parameters are required except for tags. A contact can have up to 10 tags.
 
 Note: Tags are automatically converted to lowercase when added. For example, `t/Friend` will be stored as `friend`.
+
+Note: Adding more than 10 tags to a single contact is not allowed.
 
 Format: `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...`
 
@@ -188,6 +190,8 @@ Note: Every prefix must be followed by a non-empty value, except `dt/`. `dt/` wi
 contact, while `dt/<tag>` removes only the specified tag(s).
 
 Note: Tags added with `t/` are automatically converted to lowercase before being stored.
+
+Note: A contact can only have at most 10 tags after the edit is applied.
 
 Format: `:edit <INDEX> [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [dt/TAG] ...`
 
@@ -359,7 +363,7 @@ The following enhancements are planned for future releases:
 | Command        | Format                                         | Description                                            | Example                                                                                              |
 |----------------|------------------------------------------------|--------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 | Access History | `UP` or `DOWN`                                 | Navigates to previously used commands.                 | `UP` or `DOWN`                                                                                       |
-| Add Contact    | `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...` | Adds a contact to 0rb1t. Tags are stored in lowercase. | `:add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney` |
+| Add Contact    | `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...` | Adds a contact to 0rb1t.                               | `:add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney` |
 | Add Note       | `:note <INDEX> note`                           | Adds a note to the contact.                            | `:note 2 This is an important contact.`                                                              |
 | Clear          | `:clear` + `yes`                               | Clears the entire 0rb1t.                               | `:clear`<br/>`...`<br/>`yes`                                                                         |
 | Delete         | `:delete <INDEX>` + `yes`                      | Deletes a contact from 0rb1t.                          | `:delete 2`<br/>`...`<br/>`yes`                                                                      |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -97,6 +97,8 @@ To add a contact, simply type `:add` followed by the details of the contact you 
 
 Note: All parameters are required except for tags. A contact can have any number of tags (including 0).
 
+Note: Tags are automatically converted to lowercase when added. For example, `t/Friend` will be stored as `friend`.
+
 Format: `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...`
 
 Examples:
@@ -184,6 +186,8 @@ Note: If you wish to leave some fields unchanged, you do not have to include the
 
 Note: Every prefix must be followed by a non-empty value, except `dt/`. `dt/` without a tag value removes all tags from the 
 contact, while `dt/<tag>` removes only the specified tag(s).
+
+Note: Tags added with `t/` are automatically converted to lowercase before being stored.
 
 Format: `:edit <INDEX> [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [dt/TAG] ...`
 
@@ -277,7 +281,7 @@ Expected: The contact at the given index will have a star icon next to their nam
 
 To display all the tags that you have added in 0rb1t, type `:tags` and all the tags you have added will be shown, with each tag separated by a comma.
 
-Note: Tags are displayed in alphabetical order, and each tag is shown only once even if multiple contacts have the same tag. Tags are case-sensitive; for example, “friend” and “Friend” are treated as two distinct tags.
+Note: Tags are displayed in alphabetical order, and each tag is shown only once even if multiple contacts have the same tag. Tags are stored in lowercase, so entering `Friend` and `friend` results in the same tag: `friend`.
 
 Format: `:tags`
 
@@ -355,7 +359,7 @@ The following enhancements are planned for future releases:
 | Command        | Format                                         | Description                                            | Example                                                                                              |
 |----------------|------------------------------------------------|--------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 | Access History | `UP` or `DOWN`                                 | Navigates to previously used commands.                 | `UP` or `DOWN`                                                                                       |
-| Add Contact    | `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...` | Adds a contact to 0rb1t.                               | `:add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney` |
+| Add Contact    | `:add n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]...` | Adds a contact to 0rb1t. Tags are stored in lowercase. | `:add n/John Doe p/98765432 e/johnd@example.com a/311, Clementi Ave 2, #02-25 t/friends t/owesMoney` |
 | Add Note       | `:note <INDEX> note`                           | Adds a note to the contact.                            | `:note 2 This is an important contact.`                                                              |
 | Clear          | `:clear` + `yes`                               | Clears the entire 0rb1t.                               | `:clear`<br/>`...`<br/>`yes`                                                                         |
 | Delete         | `:delete <INDEX>` + `yes`                      | Deletes a contact from 0rb1t.                          | `:delete 2`<br/>`...`<br/>`yes`                                                                      |

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -87,7 +87,12 @@ public class EditCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        Person editedPerson;
+        try {
+            editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(e.getMessage(), e);
+        }
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -48,7 +48,12 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person;
+        try {
+            person = new Person(name, phone, email, address, tagList);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage(), e);
+        }
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -16,6 +16,8 @@ import seedu.address.model.tag.Tag;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Person {
+    public static final int MAX_TAGS = 10;
+    public static final String MESSAGE_MAX_TAGS = "Each contact can have at most " + MAX_TAGS + " tags.";
 
     // Identity fields
     private final Name name;
@@ -58,6 +60,9 @@ public class Person {
     public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags,
             NoteList noteList, boolean isStarred) {
         requireAllNonNull(name, phone, email, address, tags, noteList);
+        if (tags.size() > MAX_TAGS) {
+            throw new IllegalArgumentException(MESSAGE_MAX_TAGS);
+        }
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,5 +1,7 @@
 package seedu.address.model.tag;
 
+import java.util.Locale;
+
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -22,7 +24,7 @@ public class Tag {
     public Tag(String tagName) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        this.tagName = tagName.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,8 +10,10 @@ import java.util.Locale;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final int MAX_LENGTH = 32;
+    public static final String MESSAGE_CONSTRAINTS =
+            "Tag names should be alphanumeric and at most " + MAX_LENGTH + " characters long";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}{1," + MAX_LENGTH + "}";
 
     public final String tagName;
 

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -1,10 +1,9 @@
 package seedu.address.model.tag;
 
-import java.util.Locale;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Locale;
 /**
  * Represents a Tag in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -134,6 +134,11 @@ class JsonAdaptedPerson {
         }
         final boolean modelIsStarred = isStarred != null && isStarred;
 
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelNoteList, modelIsStarred);
+        try {
+            return new Person(modelName, modelPhone, modelEmail, modelAddress,
+                    modelTags, modelNoteList, modelIsStarred);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -231,6 +231,19 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_addTagsBeyondMax_failure() {
+        Person personWithMaxTags = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+                .withTags("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10")
+                .build();
+        model.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), personWithMaxTags);
+
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags("t11").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertCommandFailure(editCommand, model, Person.MESSAGE_MAX_TAGS);
+    }
+
+    @Test
     public void execute_undoAfterEdit_restoresOriginalPerson() throws Exception {
         Person originalPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder().withTags("friends").build();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -232,7 +232,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_addTagsBeyondMax_failure() {
-        Person personWithMaxTags = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
+        Person personWithMaxTags = new PersonBuilder(
+                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
                 .withTags("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10")
                 .build();
         model.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), personWithMaxTags);

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -193,4 +193,11 @@ public class AddCommandParserTest {
                 + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_tooManyTags_failure() {
+        String tooManyTags = " t/tag1 t/tag2 t/tag3 t/tag4 t/tag5 t/tag6 t/tag7 t/tag8 t/tag9 t/tag10 t/tag11";
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + tooManyTags,
+                Person.MESSAGE_MAX_TAGS);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -26,6 +26,7 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String TOO_LONG_TAG = "a".repeat(Tag.MAX_LENGTH + 1);
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -164,6 +165,11 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTag_tooLongValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTag(TOO_LONG_TAG));
+    }
+
+    @Test
     public void parseTag_validValueWithoutWhitespace_returnsTag() throws Exception {
         Tag expectedTag = new Tag(VALID_TAG_1);
         assertEquals(expectedTag, ParserUtil.parseTag(VALID_TAG_1));
@@ -184,6 +190,11 @@ public class ParserUtilTest {
     @Test
     public void parseTags_collectionWithInvalidTags_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG)));
+    }
+
+    @Test
+    public void parseTags_collectionWithTooLongTag_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, TOO_LONG_TAG)));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -42,6 +42,13 @@ public class PersonTest {
     }
 
     @Test
+    public void constructor_moreThanMaxTags_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, Person.MESSAGE_MAX_TAGS, () ->
+                new PersonBuilder().withTags("t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10", "t11")
+                        .build());
+    }
+
+    @Test
     public void isSamePerson() {
         // same object -> returns true
         assertTrue(ALICE.isSamePerson(ALICE));

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,6 +1,8 @@
 package seedu.address.model.tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,12 @@ public class TagTest {
     }
 
     @Test
+    public void constructor_tagNameLongerThan32Characters_throwsIllegalArgumentException() {
+        String invalidTagName = "a".repeat(Tag.MAX_LENGTH + 1);
+        assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    }
+
+    @Test
     public void constructor_uppercaseTag_storesLowercase() {
         Tag tag = new Tag("FrIeNdS");
         assertEquals("friends", tag.tagName);
@@ -28,6 +36,9 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+
+        assertTrue(Tag.isValidTagName("a".repeat(Tag.MAX_LENGTH)));
+        assertFalse(Tag.isValidTagName("a".repeat(Tag.MAX_LENGTH + 1)));
     }
 
 }

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,12 @@ public class TagTest {
     public void constructor_invalidTagName_throwsIllegalArgumentException() {
         String invalidTagName = "";
         assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    }
+
+    @Test
+    public void constructor_uppercaseTag_storesLowercase() {
+        Tag tag = new Tag("FrIeNdS");
+        assertEquals("friends", tag.tagName);
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -41,6 +41,9 @@ public class JsonAdaptedPersonTest {
     private static final List<String> TOO_MANY_NOTES = java.util.stream.IntStream.range(0, NoteList.MAX_NOTES + 1)
             .mapToObj(i -> "Note " + i)
             .toList();
+    private static final List<JsonAdaptedTag> TOO_MANY_TAGS = java.util.stream.IntStream.rangeClosed(1, 11)
+            .mapToObj(i -> new JsonAdaptedTag("tag" + i))
+            .toList();
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -145,6 +148,14 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         invalidTags, VALID_NOTES, false);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_tooManyTags_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        TOO_MANY_TAGS, VALID_NOTES, false);
+        assertThrows(IllegalValueException.class, Person.MESSAGE_MAX_TAGS, person::toModelType);
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.Note;
 import seedu.address.model.person.NoteList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class JsonAdaptedPersonTest {
@@ -27,6 +28,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String TOO_LONG_TAG = "a".repeat(33);
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -148,6 +150,16 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                         invalidTags, VALID_NOTES, false);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_tooLongTag_throwsIllegalValueException() {
+        List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
+        invalidTags.add(new JsonAdaptedTag(TOO_LONG_TAG));
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        invalidTags, VALID_NOTES, false);
+        assertThrows(IllegalValueException.class, Tag.MESSAGE_CONSTRAINTS, person::toModelType);
     }
 
     @Test


### PR DESCRIPTION
Summary

- Fix inconsistent tag casing by normalizing tags to lowercase at creation time. Tags added through :add or :edit are now automatically stored in lowercase, which keeps tags listing consistent.
- Enforce constraint of 10 tags per contact.
- Enforce 32 character count for each tag.
- Update the UG to account for all of these changes.

Closes #160 
Closes #185 
Closes #178 
Closes #175 
Closes #206 